### PR TITLE
Spawn process.execPath instead of fixed 'node'

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ exports.start = function () {
     }
 
     var deferred = Q.defer();
-    server = spawn('node', config.args, config.options);
+    server = spawn(process.execPath, config.args, config.options);
     server.stdout.setEncoding('utf8');
     server.stderr.setEncoding('utf8');
 


### PR DESCRIPTION
Depending on the existance of a `node` executable is not really safe. In the future, [iojs](https://iojs.org) may not always create a `node` executable, and it’s also not safe to assume that the `node` executable in the PATH is the one that should be used (for what it matters, I don’t even have node in my path).

So just use `process.execPath` to get whatever executable was used to launch the gulpfile, which will then make sure that the process can be spawned even if `'node'` is not around.
