### PR TITLE
yield event loop to fix bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,11 +134,13 @@ exports.start = function () {
         callback.serverError(data);
     });
     server.once('exit', function (code, sig) {
-        deferred.resolve({
-            code: code,
-            signal: sig
-        });
-        callback.serverExit(code, sig);
+        setTimeout(function() { // yield event loop for stdout/stderr
+          deferred.resolve({
+              code: code,
+              signal: sig
+          });
+          callback.serverExit(code, sig);
+        }, 0)
     });
 
     process.listeners('exit') || process.once('exit', callback.processExit);


### PR DESCRIPTION
This fixes #10 . Without this fix, it exits before printing stdout or stderr.
