### PR TITLE
Clones the environment, fixed test repetition.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = exports = (function() {
             port: 35729
         }
     };
-    defaults.options.env = process.env;
+    defaults.options.env = Object.create(process.env);
     defaults.options.env.NODE_ENV = 'development';
 
     return function(args, options, livereload){

--- a/test/index.js
+++ b/test/index.js
@@ -73,10 +73,16 @@ describe('gulp-live-server', function () {
     });
 
     describe('simple new server', function(){
-        var server = undefined;
+        var server;
         var req = request('http://localhost:3000');
         before('start server', function(done){
-            gls.new(gls.script).start().then(null, null, function(){
+            server = gls.new(gls.script);
+            server.start().then(null, null, function(){
+                done();
+            }).done();
+        });
+        after('stop server', function (done) {
+            server.stop().then(function () {
                 done();
             }).done();
         });


### PR DESCRIPTION
Require'ing gulp-live-server would set the process environment's
`NODE_ENV` to `development`. By cloning the env object, it has its own
copy.

The simple test server would not stop on testing, so subsequent test
runs would fail on EADDRINUSE errors. Added an `after` to stop the
server.
