### PR TITLE
Allow setting execPath through gls.start

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Usage
         var server = gls('myapp.js', undefined, 12345);
         server.start();
 
+        //4. start with coffee-script executable e.g. installed with npm
+        var server = gls('myapp.coffee');
+        server.start('node_modules/coffee-script/bin/coffee');
+
         //use gulp.watch to trigger server actions(notify, start or stop)
     	gulp.watch(['static/**/*.css', 'static/**/*.html'], server.notify);
         gulp.watch('myapp.js', server.start); //restart my server
@@ -139,7 +143,8 @@ will be mixin into the default value:
 **`static` and `new` are just shortcuts for this.**
 Usually, `static` and `new` will serve you well, but you can get more customized server with `gls`.
 
-### start()
+### start([execPath])
+- `execPath` - `String` The executable that is used to start the server. If none is given the current node executable is used.
 - return [promise](https://github.com/kriskowal/q/wiki/API-Reference) from [Q](https://www.npmjs.com/package/q)
 
 Spawn a new child process based on the configuration.

--- a/index.js
+++ b/index.js
@@ -111,8 +111,8 @@ exports.static = function (folder, port) {
 /**
 * start/restart the server
 */
-exports.start = function () {
-    if (this.server) { // server already running
+exports.start = function (execPath) {
+    if (server) { // server already running
         debug(info('kill server'));
         this.server.kill('SIGKILL');
         //server.removeListener('exit', callback.serverExit);
@@ -124,8 +124,12 @@ exports.start = function () {
         }
     }
 
+    // if a executable is specified use that to start the server (e.g. coffeescript)
+    // otherwise use the currents process executable
+    execPath = execPath || process.execPath
+
     var deferred = Q.defer();
-    this.server = spawn(process.execPath, this.config.args, this.config.options);
+    this.server = spawn(execPath, this.config.args, this.config.options);
     this.server.stdout.setEncoding('utf8');
     this.server.stderr.setEncoding('utf8');
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ exports.static = function (folder, port) {
 * start/restart the server
 */
 exports.start = function (execPath) {
-    if (server) { // server already running
+    if (this.server) { // server already running
         debug(info('kill server'));
         this.server.kill('SIGKILL');
         //server.removeListener('exit', callback.serverExit);

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ exports.static = function (folder, port) {
 /**
 * start/restart the server
 */
-exports.start = function () {
+exports.start = function (execPath) {
     if (server) { // server already running
         debug(info('kill server'));
         server.kill('SIGKILL');
@@ -120,8 +120,12 @@ exports.start = function () {
         }
     }
 
+    // if a executable is specified use that to start the server (e.g. coffeescript)
+    // otherwise use the currents process executable
+    execPath = execPath || process.execPath
+
     var deferred = Q.defer();
-    server = spawn(process.execPath, config.args, config.options);
+    server = spawn(execPath, config.args, config.options);
     server.stdout.setEncoding('utf8');
     server.stderr.setEncoding('utf8');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-live-server",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "easy light weight server with livereload",
   "homepage": "https://github.com/gimm/gulp-live-server",
   "main": "./index.js",


### PR DESCRIPTION
Added the execPath as an optional argument to gls.start to run the server in e.g. coffee-script. Should solve #11 
