### PR TITLE
support the { stdio: 'inherit' } spawn option

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -93,5 +93,27 @@ describe('gulp-live-server', function () {
         });
     });
 
+    describe('spawn options', function() {
+        var server;
+        afterEach(function(done) {
+            if (!server) {
+                done();
+                return;
+            }
+
+            server.stop().then(function() {
+                done();
+            }).done();
+        });
+
+        it('should not explode if stdio is set to "inherit"', function(done) {
+            var options = {
+                stdio: 'inherit'
+            };
+            server = gls(gls.script, options, false);
+            server.start();
+            done();
+        });
+    });
 
 });


### PR DESCRIPTION
The reason why this is nice is that using `stdio: 'inherit'` allows the original log message colors to be propagated.
