### PR TITLE
Modified the callback passed to gulp watch in both example tasks

### DIFF
--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -4,7 +4,9 @@ var gls = require('../index.js');
 gulp.task('static', function() {
     var server = gls.static('static', 8000);
     server.start();
-    gulp.watch(['static/**/*.css', 'static/**/*.html'], server.notify);
+    gulp.watch(['static/**/*.css', 'static/**/*.html'], function(file) {
+        server.notify.apply(server, [file]);
+    });
 });
 
 gulp.task('custom', function() {
@@ -13,6 +15,8 @@ gulp.task('custom', function() {
         console.log('Server exited with result:', result);
         process.exit(result.code);
     });
-    gulp.watch(['static/**/*.css', 'static/**/*.html'], server.notify);
+    gulp.watch(['static/**/*.css', 'static/**/*.html'], function(file) {
+        server.notify.apply(server, [file]);
+    });
     gulp.watch('server.js', server.start);
 });


### PR DESCRIPTION
I cloned this repo and tried running the example gulp tasks. Both the `static` and `custom` tasks ran and the tiny-lr and connect servers started. They served files as expected but whenever a watched file was changed the following error was thrown..

```
/Github/gulp-live-server/index.js:204
    var lr = this.lr;
                 ^
TypeError: Cannot read property 'lr' of undefined
    at exports.notify (/Github/gulp-live-server/index.js:204:15)
    at Gaze.<anonymous> (/Github/gulp-live-server/node_modules/gulp/node_modules/vinyl-fs/node_modules/glob-watcher/index.js:18:14)
    at Gaze.emit (events.js:98:17)
    at Gaze.emit (/Github/gulp-live-server/node_modules/gulp/node_modules/vinyl-fs/node_modules/glob-watcher/node_modules/gaze/lib/gaze.js:129:32)
    at /Github/gulp-live-server/node_modules/gulp/node_modules/vinyl-fs/node_modules/glob-watcher/node_modules/gaze/lib/gaze.js:415:16
    at StatWatcher._pollers.(anonymous function) (/Github/gulp-live-server/node_modules/gulp/node_modules/vinyl-fs/node_modules/glob-watcher/node_modules/gaze/lib/gaze.js:326:7)
    at StatWatcher.emit (events.js:98:17)
    at StatWatcher._handle.onchange (fs.js:1116:10)
```

I presume this is because `server.notify` is being called with no context.

_Action Taken_
- Wrapped watch callback in a function
- Invoked `server.notify` with the context `server`
- Pass in array of changed files `[file]` to `server.notify`

This seems to fix the problem!
