### PR TITLE
Fix indented logs in stdout, stderr and colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ var callback = {
     },
 
     serverLog: function (data) {
-        console.log(info(data.trim()));
+        console.log(data.replace(/\s+$/, ''));
     },
 
     serverError: function (data) {
-        console.log(error(data.trim()));
+        console.log(error(data.replace(/\s+$/, '')));
     }
 };
 


### PR DESCRIPTION
Instead of trim() now only trimming from the right side.

Removed the info() to be able to see original colors by stdout.

Fixes #66 and #67 